### PR TITLE
Fix: agregar MYSQL_ALLOW_EMPTY_PASSWORD en la configuración de MySQL

### DIFF
--- a/caso-001/docker-compose.yml
+++ b/caso-001/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     image: mysql:8
     restart: always
     environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
       MYSQL_ROOT_PASSWORD: ${DATABASE_PASSWORD}
       MYSQL_DATABASE: ${DATABASE_NAME}
     ports:


### PR DESCRIPTION
✅ con esta configuración permitimos que la base de datos pueda tener una contraseña vacía , ya que sino a la hora de tomar los datos del .env si no contiene nada en DATABASE_PASSWORD tira un error :)